### PR TITLE
allow local image files in webgl context

### DIFF
--- a/modules/html/producer/html_producer.cpp
+++ b/modules/html/producer/html_producer.cpp
@@ -459,6 +459,7 @@ public:
 
 			CefBrowserSettings browser_settings;
 			browser_settings.web_security = cef_state_t::STATE_DISABLED;
+			browser_settings.universal_access_from_file_urls = cef_state_t::STATE_ENABLED;
 			CefBrowserHost::CreateBrowser(window_info, client_.get(), url, browser_settings, nullptr);
 		});
 	}


### PR DESCRIPTION
local image files cannot be loaded webgl context.
added ;
browser_settings.universal_access_from_file_urls = cef_state_t::STATE_ENABLED;
related link below,
https://answers.unrealengine.com/questions/674383/tampering-allow-files-access-from-cef-browser-and.html